### PR TITLE
SDK maintenance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ val commonSettings = Seq(
   organization := "com.igeolise",
   bintrayOrganization := Some("igeolise"),
   name := "traveltime-platform-sdk",
-  version := "1.3.0",
-  crossScalaVersions := Seq("2.12.8", "2.11.12"),
+  version := "1.4.0",
+  crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "utf-8",
@@ -18,12 +18,11 @@ val commonSettings = Seq(
     "-Ywarn-dead-code"
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "cats-core" % "1.1.0",
-    "com.softwaremill.sttp" %%% "core" % "1.3.9",
-    "com.typesafe.play" %%% "play-json" % "2.6.10",
+    "org.typelevel" %%% "cats-core" % "2.0.0-M4",
+    "com.softwaremill.sttp" %%% "core" % "1.6.0",
+    "com.typesafe.play" %%% "play-json" % "2.7.4",
     "com.beachape" %%% "enumeratum" % "1.5.13",
-    "org.scalatest" %%% "scalatest" % "3.0.5" % "test",
-    "org.scalactic" %%% "scalactic" % "3.0.5" % "test",
+    "org.scalatest" %% "scalatest" % "3.1.0-SNAP13" % Test,
   ),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 )
@@ -33,13 +32,13 @@ lazy val sdk =
     .settings(commonSettings)
     .jvmSettings(
       libraryDependencies ++= Seq(
-        "com.softwaremill.sttp" %% "async-http-client-backend-future" % "1.3.6"
+        "com.softwaremill.sttp" %% "okhttp-backend" % "1.6.0"
       )
     )
     .jsSettings(
       libraryDependencies ++= Seq(
-        "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC1",
-        "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0-RC1_2018f"
+        "io.github.cquiroz" %%% "scala-java-time" % "2.0.0-RC3",
+        "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.0.0-RC3_2019a"
       )
     )
 

--- a/jvm/src/main/scala/com/igeolise/traveltimesdk/DefaultBackend.scala
+++ b/jvm/src/main/scala/com/igeolise/traveltimesdk/DefaultBackend.scala
@@ -1,10 +1,10 @@
 package com.igeolise.traveltimesdk
 
 import com.softwaremill.sttp.SttpBackend
-import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
+import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
 
 import scala.concurrent.Future
 
 object DefaultBackend {
-  def backend: SttpBackend[Future, Nothing] = AsyncHttpClientFutureBackend()
+  def backend: SttpBackend[Future, Nothing] = OkHttpFutureBackend()
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.26")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.1")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.28")
 addSbtPlugin("org.foundweekends"  % "sbt-bintray"                   % "0.5.4")

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/TravelTimeSDK.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/TravelTimeSDK.scala
@@ -1,9 +1,10 @@
 package com.igeolise.traveltimesdk
 
 import cats.Monad
-import com.igeolise.traveltimesdk.dto.requests.RequestUtils.{SttpRequest, TravelTimePlatformRequest}
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.{SttpRequest, TravelTimePlatformRequest, TravelTimePlatformResponse}
 import com.igeolise.traveltimesdk.dto.responses.TravelTimeSdkError
 import com.softwaremill.sttp.{SttpBackend, Uri, _}
+import com.igeolise.traveltimesdk.TravelTimeSDK.DEFAULT_HOST
 
 import scala.concurrent.Future
 import scala.language.higherKinds
@@ -14,10 +15,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 case class TravelTimeSDK[R[_] : Monad, S](
   credentials: ApiCredentials,
   backend: SttpBackend[R, S],
-  host: Uri = uri"api.traveltimeapp.com"
+  host: Uri = DEFAULT_HOST
 ) {
 
-  def send[A](request: TravelTimePlatformRequest[A]): R[Either[TravelTimeSdkError, A]] = {
+  def send[A <: TravelTimePlatformResponse](
+    request: TravelTimePlatformRequest[A]
+  ): R[Either[TravelTimeSdkError, A]] = {
     val baseRequest = request.sttpRequest(host).headers(credentials.toMap)
     val req = SttpRequest[R, S](backend, baseRequest)
     request.send(req)

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/common/Zone.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/common/Zone.scala
@@ -17,10 +17,10 @@ case class ZoneSearchProperties(
 )
 
 case class TravelTime(
-  min: Int,
-  max: Int,
-  mean: Int,
-  median: Int
+  min: FiniteDuration,
+  max: FiniteDuration,
+  mean: FiniteDuration,
+  median: FiniteDuration
 )
 
 object ZoneSearches{

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/GeocodingRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/GeocodingRequest.scala
@@ -24,8 +24,9 @@ case class GeocodingRequest(
   query: String, focusCoords: Option[Coords] = None, countryCode: Option[String] = None
 ) extends TravelTimePlatformRequest[GeoJsonResponse[GeocodingResponseProperties]]  {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, GeoJsonResponse[GeocodingResponseProperties]]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, GeoJsonResponse[GeocodingResponseProperties]]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[GeoJsonResponse[GeocodingResponseProperties]]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/RoutesRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/RoutesRequest.scala
@@ -27,13 +27,12 @@ case class RoutesRequest(
       _.validate[RoutesResponse]
     )
 
-  override def sttpRequest(host: Uri): Request[String, Nothing] = {
+  override def sttpRequest(host: Uri): Request[String, Nothing] =
     RequestUtils.makePostRequest(
       Json.toJson(this),
       "v4/routes",
       host
     ).headers(HeaderNames.Accept -> MediaTypes.Json)
-  }
 }
 
 object RoutesRequest {

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/SupportedLocationsRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/SupportedLocationsRequest.scala
@@ -13,8 +13,9 @@ case class SupportedLocationsRequest(
   locations: Seq[Location]
 ) extends TravelTimePlatformRequest[SupportedLocationsResponse] {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, SupportedLocationsResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, SupportedLocationsResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[SupportedLocationsResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/TimeMapBoxesRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/TimeMapBoxesRequest.scala
@@ -16,8 +16,9 @@ case class TimeMapBoxesRequest(
   intersectionSearches: Seq[Intersection]
 ) extends TravelTimePlatformRequest[TimeMapBoxesResponse]  {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeMapBoxesResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeMapBoxesResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeMapBoxesResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/TimeMapRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/TimeMapRequest.scala
@@ -30,8 +30,9 @@ case class TimeMapRequest(
     ).headers(HeaderNames.Accept -> MediaTypes.Json)
   }
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeMapResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeMapResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeMapResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/TimeMapWktRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/TimeMapWktRequest.scala
@@ -18,13 +18,13 @@ case class TimeMapWktRequest(
 )(holesSetting: HolesSetting = WithHoles)
   extends TravelTimePlatformRequest[TimeMapWktResponse] {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeMapWktResponse]] = {
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeMapWktResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeMapWktResponse]
     )
-  }
 
   override def sttpRequest(host: Uri): Request[String, Nothing] = {
     def req = RequestUtils.makePostRequest(

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/CommonProperties.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/CommonProperties.scala
@@ -6,46 +6,46 @@ import scala.collection.immutable
 
 object CommonProperties {
   sealed trait PropertyType extends EnumEntry { val propertyType: String }
-  sealed trait TimeFilterZonesProperty extends PropertyType
-  sealed trait RoutesRequestProperty extends PropertyType
-  sealed trait TimeFilterFastProperty extends PropertyType
-  sealed trait TimeFilterPostcodesProperty extends PropertyType
-  sealed trait TimeMapRequestProperty extends PropertyType
-  sealed trait TimeFilterRequestProperty extends PropertyType
+  sealed trait RoutesRequestProperty        extends PropertyType
+  sealed trait TimeFilterFastProperty       extends PropertyType
+  sealed trait TimeMapRequestProperty       extends PropertyType
+  sealed trait TimeFilterZonesProperty      extends PropertyType
+  sealed trait TimeFilterRequestProperty    extends PropertyType
+  sealed trait TimeFilterPostcodesProperty  extends PropertyType
 
   object PropertyType extends Enum[PropertyType] {
     val values: immutable.IndexedSeq[PropertyType] = findValues
 
-    case object travelTime extends TimeFilterRequestProperty
+    case object TravelTime extends TimeFilterRequestProperty
       with TimeFilterPostcodesProperty with RoutesRequestProperty with TimeFilterFastProperty {
       override val propertyType: String = "travel_time"
     }
 
-    case object distance extends TimeFilterRequestProperty with TimeFilterPostcodesProperty with RoutesRequestProperty{
+    case object Distance extends TimeFilterRequestProperty with TimeFilterPostcodesProperty with RoutesRequestProperty{
       override val propertyType: String = "distance"
     }
 
-    case object travelTimeReachable extends TimeFilterZonesProperty  {
+    case object TravelTimeReachable extends TimeFilterZonesProperty  {
       override val propertyType = "travel_time_reachable"
     }
 
-    case object travelTimeAll extends TimeFilterZonesProperty {
+    case object TravelTimeAll extends TimeFilterZonesProperty {
       override val propertyType = "travel_time_all"
     }
 
-    case object coverage extends TimeFilterZonesProperty  {
+    case object Coverage extends TimeFilterZonesProperty  {
       override val propertyType = "coverage"
     }
 
-    case object fares extends TimeFilterRequestProperty with RoutesRequestProperty with TimeFilterFastProperty{
+    case object Fares extends TimeFilterRequestProperty with RoutesRequestProperty with TimeFilterFastProperty{
       override val propertyType: String = "fares"
     }
 
-    case object route extends TimeFilterRequestProperty with RoutesRequestProperty {
+    case object Route extends TimeFilterRequestProperty with RoutesRequestProperty {
       override val propertyType: String = "route"
     }
 
-    case object distanceBreakdown extends TimeFilterRequestProperty {
+    case object DistanceBreakdown extends TimeFilterRequestProperty {
       override val propertyType: String = "distance_breakdown"
     }
 

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/RangeParams.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/RangeParams.scala
@@ -1,6 +1,8 @@
 package com.igeolise.traveltimesdk.dto.requests.common
 
+import scala.concurrent.duration.FiniteDuration
+
 object RangeParams {
-  case class FullRangeParams(enabled: Boolean, max_results: Int, width: Int)
-  case class RangeParams(enabled: Boolean, width: Int)
+  case class FullRangeParams(enabled: Boolean, max_results: Int, width: FiniteDuration)
+  case class RangeParams(enabled: Boolean, width: FiniteDuration)
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/Transportation.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/Transportation.scala
@@ -5,23 +5,28 @@ import enumeratum.{Enum, EnumEntry}
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
-sealed trait Transportation extends EnumEntry { val transportType: String }
+sealed trait Transportation               extends EnumEntry { val transportType: String }
 sealed trait CommonTransportation         extends Transportation
 sealed trait TimeFilterFastTransportation extends Transportation
-
-sealed trait FerryTransportation          extends Transportation with CommonTransportation
-  {val parameters: FerryParams}
-
-sealed trait PublicTransportation         extends Transportation with CommonTransportation
-  {val parameters: PublicTransportationParams}
+sealed trait FerryTransportation          extends Transportation with CommonTransportation{
+  val parameters: FerryParams
+}
+sealed trait PublicTransportation         extends Transportation with CommonTransportation{
+  val parameters: PublicTransportationParams
+}
 
 case class PublicTransportationParams(
   ptChangeDelay: Option[FiniteDuration] = None,
   walkingTime: Option[FiniteDuration] = None
 )
 
-case class FerryParams(boardingTime: Option[FiniteDuration] = None){
-}
+case class CyclingPublicTransportParams(
+  cyclingToStationTime: Option[FiniteDuration],
+  parkingTime: Option[FiniteDuration],
+  boardingTime: Option[FiniteDuration]
+)
+
+case class FerryParams(boardingTime: Option[FiniteDuration] = None)
 
 case class DrivingTrainParams(
   drivingTimeToStation: Option[FiniteDuration] = None,
@@ -33,17 +38,35 @@ case class DrivingTrainParams(
 object Transportation extends Enum[Transportation] {
   val values: immutable.IndexedSeq[Transportation] = findValues
 
-  case object CyclingFerry extends Transportation {
-    override val transportType: String = "cycling+ferry"
-  }
-
-  case class CyclingFerry(params: FerryParams) extends FerryTransportation {
-    override val transportType: String = "cycling+ferry"
-    override val parameters: FerryParams = params
-  }
-
   case object PublicTransport extends TimeFilterFastTransportation with CommonTransportation {
     override val transportType: String = "public_transport"
+
+    case object Bus extends Transportation {
+      override val transportType: String = "bus"
+    }
+
+    case class Bus(params: PublicTransportationParams) extends PublicTransportation {
+      override val transportType = "bus"
+      override val parameters: PublicTransportationParams = params
+    }
+
+    case object Train extends Transportation {
+      override val transportType: String = "train"
+    }
+
+    case class Train(params: PublicTransportationParams) extends PublicTransportation {
+      override val transportType = "train"
+      override val parameters: PublicTransportationParams = params
+    }
+
+    case object Coach extends Transportation {
+      override val transportType: String = "coach"
+    }
+
+    case class Coach(params: PublicTransportationParams) extends PublicTransportation {
+      override val transportType = "coach"
+      override val parameters: PublicTransportationParams = params
+    }
   }
 
   case class PublicTransport(params: PublicTransportationParams) extends PublicTransportation {
@@ -51,39 +74,16 @@ object Transportation extends Enum[Transportation] {
     override val parameters: PublicTransportationParams = params
   }
 
-  case object Coach extends Transportation{
-    override val transportType: String = "coach"
+  case object Driving extends TimeFilterFastTransportation with CommonTransportation {
+    override val transportType = "driving"
   }
 
-  case class Coach(params: PublicTransportationParams) extends PublicTransportation {
-    override val transportType = "coach"
-    override val parameters: PublicTransportationParams = params
+  case object Cycling extends Transportation with CommonTransportation {
+    override val transportType = "cycling"
   }
 
-  case object Bus extends Transportation{
-    override val transportType: String = "bus"
-  }
-
-  case class Bus(params: PublicTransportationParams) extends PublicTransportation {
-    override val transportType = "bus"
-    override val parameters: PublicTransportationParams = params
-  }
-
-  case object Train extends Transportation{
-    override val transportType: String = "train"
-  }
-
-  case class Train(params: PublicTransportationParams) extends PublicTransportation {
-    override val transportType = "train"
-    override val parameters: PublicTransportationParams = params
-  }
-
-  case object DrivingTrain extends Transportation{
-    override val transportType: String = "driving+train"
-  }
-
-  case class DrivingTrain(params: DrivingTrainParams) extends Transportation with CommonTransportation {
-    override val transportType = "driving+train"
+  case object Walking extends Transportation with CommonTransportation {
+    override val transportType = "walking"
   }
 
   case object Ferry extends Transportation {
@@ -95,16 +95,28 @@ object Transportation extends Enum[Transportation] {
     override val parameters: FerryParams = params
   }
 
-  case object Cycling extends Transportation with CommonTransportation {
-    override val transportType = "cycling"
+  case object CyclingPublicTransport extends CommonTransportation {
+    override val transportType: String = "cycling+public_transport"
+  }
+  case class CyclingPublicTransport(params: CyclingPublicTransportParams) extends CommonTransportation {
+    override val transportType: String = "cycling+public_transport"
   }
 
-  case object Driving extends TimeFilterFastTransportation with CommonTransportation {
-    override val transportType = "driving"
+  case object CyclingFerry extends Transportation {
+    override val transportType: String = "cycling+ferry"
   }
 
-  case object Walking extends Transportation with CommonTransportation {
-    override val transportType = "walking"
+  case class CyclingFerry(params: FerryParams) extends FerryTransportation {
+    override val transportType: String = "cycling+ferry"
+    override val parameters: FerryParams = params
+  }
+
+  case object DrivingTrain extends Transportation {
+    override val transportType: String = "driving+train"
+  }
+
+  case class DrivingTrain(params: DrivingTrainParams) extends Transportation with CommonTransportation {
+    override val transportType = "driving+train"
   }
 
   case object DrivingFerry extends Transportation {

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterFastRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterFastRequest.scala
@@ -19,8 +19,9 @@ case class TimeFilterFastRequest(
   arrivalSearches: ArrivalSearch
 ) extends TravelTimePlatformRequest[TimeFilterFastResponse] {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeFilterFastResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeFilterFastResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeFilterFastResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterPostcodesRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterPostcodesRequest.scala
@@ -20,8 +20,9 @@ case class TimeFilterPostcodesRequest(
   arrivalSearches:   Seq[TimeFilterPostcodesRequest.ArrivalSearch]
 ) extends TravelTimePlatformRequest[TimeFilterPostcodesResponse] {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeFilterPostcodesResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeFilterPostcodesResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeFilterPostcodesResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterRequest.scala
@@ -21,8 +21,9 @@ case class TimeFilterRequest(
   arrivalSearches:   Seq[TimeFilterRequest.ArrivalSearch]
 ) extends TravelTimePlatformRequest[TimeFilterResponse] {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeFilterResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeFilterResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeFilterResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterSectorsRequest.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/timefilter/TimeFilterSectorsRequest.scala
@@ -16,8 +16,9 @@ case class TimeFilterSectorsRequest(
   arrivalSearch: Seq[ArrivalSearch]
 ) extends TravelTimePlatformRequest[TimeFilterSectorsResponse] {
 
-  override def send[R[_] : Monad, S](sttpRequest: RequestUtils.SttpRequest[R, S])
-  : R[Either[TravelTimeSdkError, TimeFilterSectorsResponse]] =
+  override def send[R[_] : Monad, S](
+    sttpRequest: RequestUtils.SttpRequest[R, S]
+  ): R[Either[TravelTimeSdkError, TimeFilterSectorsResponse]] =
     RequestUtils.send(
       sttpRequest,
       _.validate[TimeFilterSectorsResponse]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/GeoJsonResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/GeoJsonResponse.scala
@@ -1,8 +1,9 @@
 package com.igeolise.traveltimesdk.dto.responses
 
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import play.api.libs.json.JsValue
 
-case class GeoJsonResponse[A](feature: GeoJsonResponse.Feature[A]) {
+case class GeoJsonResponse[A](feature: GeoJsonResponse.Feature[A]) extends TravelTimePlatformResponse {
   def inMap[B](fun: GeoJsonResponse.SingleFeature[A] => B): GeoJsonResponse[B] = feature match {
     case f: GeoJsonResponse.SingleFeature[A] =>
       GeoJsonResponse(f.copy(properties = fun(f)))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/MapInfoResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/MapInfoResponse.scala
@@ -1,10 +1,12 @@
 package com.igeolise.traveltimesdk.dto.responses
 
 import java.time.ZonedDateTime
+
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.MapInfoResponse.Map
 import play.api.libs.json.JsValue
 
-case class MapInfoResponse(maps: Seq[Map], raw: JsValue)
+case class MapInfoResponse(maps: Seq[Map], raw: JsValue) extends TravelTimePlatformResponse
 
 object MapInfoResponse {
   case class Map(
@@ -22,5 +24,4 @@ object MapInfoResponse {
     dateStart: ZonedDateTime,
     dateEnd: ZonedDateTime
   )
-
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/RoutesResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/RoutesResponse.scala
@@ -1,11 +1,13 @@
 package com.igeolise.traveltimesdk.dto.responses
 
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.RoutesResponse.SingleSearchResult
 import com.igeolise.traveltimesdk.dto.responses.common.{Fares, Route}
 import play.api.libs.json.JsValue
+
 import scala.concurrent.duration.FiniteDuration
 
-case class RoutesResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class RoutesResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object RoutesResponse {
   case class SingleSearchResult(

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/SupportedLocationsResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/SupportedLocationsResponse.scala
@@ -1,5 +1,6 @@
 package com.igeolise.traveltimesdk.dto.responses
 
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.SupportedLocationsResponse.Location
 import play.api.libs.json.JsValue
 
@@ -7,10 +8,10 @@ case class SupportedLocationsResponse(
   locations: Seq[Location],
   unsupportedLocations: Seq[String],
   raw: JsValue
-)
+) extends TravelTimePlatformResponse
 
 object SupportedLocationsResponse {
-  sealed case class Location(
+  case class Location(
     id: String,
     mapName: String
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TimeMapBoxesResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TimeMapBoxesResponse.scala
@@ -1,10 +1,11 @@
 package com.igeolise.traveltimesdk.dto.responses
 
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.TimeMapProps.TimeMapResponseProperties
 import com.igeolise.traveltimesdk.dto.responses.TimeMapBoxesResponse.SingleSearchResult
 import play.api.libs.json.JsValue
 
-case class TimeMapBoxesResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeMapBoxesResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeMapBoxesResponse {
   case class SingleSearchResult(

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TimeMapResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TimeMapResponse.scala
@@ -1,20 +1,21 @@
 package com.igeolise.traveltimesdk.dto.responses
 
 import com.igeolise.traveltimesdk.dto.common.Coords
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.TimeMapProps.TimeMapResponseProperties
 import com.igeolise.traveltimesdk.dto.responses.TimeMapResponse.SingleSearchResult
 import play.api.libs.json.JsValue
 
-case class TimeMapResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeMapResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeMapResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     searchId: String,
     shapes: Seq[Shape],
     properties: TimeMapResponseProperties
   )
 
-  sealed case class Shape(
+  case class Shape(
     shell: Seq[Coords],
     holes: Seq[Seq[Coords]]
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TimeMapWktResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TimeMapWktResponse.scala
@@ -1,20 +1,21 @@
 package com.igeolise.traveltimesdk.dto.responses
 
 import com.igeolise.traveltimesdk.dto.common.Coords
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.TimeMapProps.TimeMapResponseProperties
 import com.igeolise.traveltimesdk.dto.responses.TimeMapWktResponse.SingleSearchResult
 import play.api.libs.json.JsValue
 
-case class TimeMapWktResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeMapWktResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeMapWktResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     searchId: String,
     shape: String,
     properties: TimeMapResponseProperties
   )
 
-  sealed case class Shape(
+  case class Shape(
     shell: Seq[Coords],
     holes: Seq[Seq[Coords]]
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TravelTimeSdkError.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/TravelTimeSdkError.scala
@@ -6,10 +6,10 @@ sealed trait TravelTimeSdkError
 
 object TravelTimeSdkError {
   case class ConnectionError(cause: Throwable) extends TravelTimeSdkError
-  case class ErrorResponse(response: ErroResponseDetails) extends TravelTimeSdkError
+  case class ErrorResponse(response: ErrorResponseDetails) extends TravelTimeSdkError
   case class ValidationError(err: JsError) extends TravelTimeSdkError
 
-  case class ErroResponseDetails(
+  case class ErrorResponseDetails(
     httpStatus: Int,
     code: Int,
     description: String,

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/common/DistanceBreakdown.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/common/DistanceBreakdown.scala
@@ -1,0 +1,13 @@
+package com.igeolise.traveltimesdk.dto.responses.common
+
+import com.igeolise.traveltimesdk.dto.responses.common.DistanceBreakdown.BreakdownPart
+
+case class DistanceBreakdown(parts: Seq[BreakdownPart])
+
+object DistanceBreakdown {
+
+  case class BreakdownPart(
+    mode: String,
+    distanceMeters: Int
+  )
+}

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterDistrictsResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterDistrictsResponse.scala
@@ -1,13 +1,14 @@
 package com.igeolise.traveltimesdk.dto.responses.timefilter
 
 import com.igeolise.traveltimesdk.dto.common.Zone
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterDistrictsResponse.SingleSearchResult
 import play.api.libs.json.JsValue
 
-case class TimeFilterDistrictsResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeFilterDistrictsResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeFilterDistrictsResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     id: String,
     districts: Seq[Zone]
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterFastResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterFastResponse.scala
@@ -1,31 +1,33 @@
 package com.igeolise.traveltimesdk.dto.responses.timefilter
 
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterFastResponse.SingleSearchResult
 import play.api.libs.json.JsValue
+
 import scala.concurrent.duration.FiniteDuration
 
-case class TimeFilterFastResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeFilterFastResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeFilterFastResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     searchId: String,
     locations: Seq[Location],
     unreachable: Seq[String]
   )
 
-  sealed case class Location(
+  case class Location(
     id: String,
     properties: Properties
   )
 
-  sealed case class Properties(
+  case class Properties(
     travelTime: Option[FiniteDuration],
     fares: Fares
   )
 
-  sealed case class Fares(ticketsTotal: Seq[Ticket])
+  case class Fares(ticketsTotal: Seq[Ticket])
 
-  sealed case class Ticket(
+  case class Ticket(
     `type`: String,
     price: Double,
     currency: String

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterPostcodesResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterPostcodesResponse.scala
@@ -1,23 +1,25 @@
 package com.igeolise.traveltimesdk.dto.responses.timefilter
 
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterPostcodesResponse.SingleSearchResult
 import play.api.libs.json.JsValue
+
 import scala.concurrent.duration.FiniteDuration
 
-case class TimeFilterPostcodesResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeFilterPostcodesResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeFilterPostcodesResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     id: String,
     postCodes: Seq[Postcode]
   )
 
-  sealed case class Postcode(
+  case class Postcode(
     code: String,
     properties: Seq[PostcodesProperties]
   )
 
-  sealed case class PostcodesProperties(
+  case class PostcodesProperties(
     travelTime: Option[FiniteDuration],
     distance: Option[Int]
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterResponse.scala
@@ -1,27 +1,30 @@
 package com.igeolise.traveltimesdk.dto.responses.timefilter
 
-import com.igeolise.traveltimesdk.dto.responses.common.{Fares, Route}
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
+import com.igeolise.traveltimesdk.dto.responses.common.{DistanceBreakdown, Fares, Route}
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterResponse.SingleSearchResult
 import play.api.libs.json.JsValue
+
 import scala.concurrent.duration.FiniteDuration
 
-case class TimeFilterResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeFilterResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeFilterResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     searchId: String,
     locations: Seq[Location],
     unreachable: Seq[String]
   )
 
-  sealed case class Location(
+  case class Location(
     id: String,
     properties: Seq[Properties]
   )
 
-  sealed case class Properties(
+  case class Properties(
     travelTime: Option[FiniteDuration] = None,
     distanceMeters: Option[Int] = None,
+    distanceBreakdown: Option[DistanceBreakdown] = None,
     fares: Option[Fares] = None,
     route: Option[Route] = None
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterSectorsResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterSectorsResponse.scala
@@ -1,13 +1,14 @@
 package com.igeolise.traveltimesdk.dto.responses.timefilter
 
 import com.igeolise.traveltimesdk.dto.common.Zone
+import com.igeolise.traveltimesdk.dto.requests.RequestUtils.TravelTimePlatformResponse
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterSectorsResponse.SingleSearchResult
 import play.api.libs.json.JsValue
 
-case class TimeFilterSectorsResponse(results: Seq[SingleSearchResult], raw: JsValue)
+case class TimeFilterSectorsResponse(results: Seq[SingleSearchResult], raw: JsValue) extends TravelTimePlatformResponse
 
 object TimeFilterSectorsResponse {
-  sealed case class SingleSearchResult(
+  case class SingleSearchResult(
     id: String,
     sectors: Seq[Zone]
   )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/AvailableDataReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/AvailableDataReads.scala
@@ -7,34 +7,35 @@ import play.api.libs.json.{JsValue, Reads, __}
 import CommonReads._
 
 object AvailableDataReads {
-  implicit val supportedLocationsLocationReadsV4: Reads[SupportedLocationsResponse.Location] = (
+
+  implicit val supportedLocationsLocationReads: Reads[SupportedLocationsResponse.Location] = (
     (__ \ "id").read[String] and
     (__ \ "map_name").read[String]
   )(SupportedLocationsResponse.Location.apply _)
 
-  implicit val SupportedLocationsResultReadsV4: Reads[SupportedLocationsResponse] = (
+  implicit val supportedLocationsResultReads: Reads[SupportedLocationsResponse] = (
     (__ \ "locations").read[Seq[SupportedLocationsResponse.Location]] and
     (__ \ "unsupported_locations").read[Seq[String]] and
     __.read[JsValue]
   )(SupportedLocationsResponse.apply _)
 
-  implicit val mapInfoPTReadsV4: Reads[MapInfoResponse.PublicTransportData] = (
+  implicit val mapInfoPTReads: Reads[MapInfoResponse.PublicTransportData] = (
     (__ \ "date_start").read[ZonedDateTime] and
     (__ \ "date_end").read[ZonedDateTime]
   )(MapInfoResponse.PublicTransportData.apply _)
 
-  implicit val mapInfoFeaturesReadsV4: Reads[MapInfoResponse.Features] = (
+  implicit val mapInfoFeaturesReads: Reads[MapInfoResponse.Features] = (
     (__ \ "public_transport").readNullable[MapInfoResponse.PublicTransportData] and
     (__ \ "fares").read[Boolean] and
     (__ \ "postcodes").read[Boolean]
   )(MapInfoResponse.Features.apply _)
 
-  implicit val mapInfoMapReadsV4: Reads[MapInfoResponse.Map] = (
+  implicit val mapInfoMapReads: Reads[MapInfoResponse.Map] = (
     (__ \ "name").read[String] and
     (__ \ "features").read[MapInfoResponse.Features]
   )(MapInfoResponse.Map.apply _)
 
-  implicit val MapInfoResultReadsV4: Reads[MapInfoResponse] = (
+  implicit val mapInfoResultReads: Reads[MapInfoResponse] = (
     (__ \ "maps").read[Vector[MapInfoResponse.Map]] and
     __.read[JsValue]
   )(MapInfoResponse.apply _)

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/CommonReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/CommonReads.scala
@@ -1,11 +1,15 @@
 package com.igeolise.traveltimesdk.json.reads
 
 import java.time.ZonedDateTime
+
 import com.igeolise.traveltimesdk.dto.common.{Coords, TravelTime, Zone, ZoneSearchProperties}
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.TimeMapProps.TimeMapResponseProperties
+import com.igeolise.traveltimesdk.dto.responses.common.Route.RoutePart
+import com.igeolise.traveltimesdk.dto.responses.common.Route.RoutePart.{BasicRoutePart, PublicTransportRoutePart}
 import com.igeolise.traveltimesdk.dto.responses.common.{Fares, Route}
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Reads, __}
+
 import scala.concurrent.duration.{Duration, FiniteDuration, SECONDS}
 
 object CommonReads {
@@ -24,13 +28,13 @@ object CommonReads {
     (__ \ "lng").read[Double]
   ) (Coords)
 
-  implicit val ticketReadsV4: Reads[Fares.Ticket] = (
+  implicit val ticketReads: Reads[Fares.Ticket] = (
     (__ \ "type").read[String] and
     (__ \ "price").read[Double] and
     (__ \ "currency").read[String]
   ) (Fares.Ticket.apply _)
 
-  implicit val fareBreakdownReadsV4: Reads[Fares.FareBreakdown] = (
+  implicit val fareBreakdownReads: Reads[Fares.FareBreakdown] = (
     (__ \ "modes").read[Seq[String]] and
     (__ \ "route_part_ids").read[Seq[Int]] and
     (__ \ "tickets").read[Seq[Fares.Ticket]]
@@ -41,7 +45,7 @@ object CommonReads {
     (__ \ "tickets_total").read[Seq[Fares.Ticket]]
   ) (Fares.apply _)
 
-  implicit val basicRoutePartReadsV4: Reads[Route.RoutePart.BasicRoutePart] = (
+  implicit val basicRoutePartReads: Reads[BasicRoutePart] = (
     (__ \ "id").read[Int] and
     (__ \ "type").read[String] and
     (__ \ "mode").read[String] and
@@ -49,50 +53,50 @@ object CommonReads {
     (__ \ "distance").read[Int] and
     (__ \ "travel_time").read[FiniteDuration](secondsToFiniteDurationReads) and
     (__ \ "coords").read[Seq[Coords]](Reads.seq(coordsReads))
-  ) (Route.RoutePart.BasicRoutePart.apply _)
+  ) (BasicRoutePart.apply _)
 
-  val startEndRoutePartReadsV4: Reads[Route.RoutePart.StartEndRoutePart] = (
+  val startEndRoutePartReads: Reads[Route.RoutePart.StartEndRoutePart] = (
     __.read[Route.RoutePart.BasicRoutePart] and
     (__ \ "direction").read[String]
   ) ((basic: Route.RoutePart.BasicRoutePart, direction: String) =>
-    Route.RoutePart.StartEndRoutePart(
-      basic.id, basic.`type`, basic.mode, basic.directions, basic.distanceMeters, basic.travelTime, basic.coords,
-      direction
-    )
+     Route.RoutePart.StartEndRoutePart(
+         basic.id, basic.`type`, basic.mode, basic.directions, basic.distanceMeters, basic.travelTime, basic.coords,
+         direction
+     )
   )
-
-  val roadRoutePartReadsV4: Reads[Route.RoutePart.RoadRoutePart] = (
+  val roadRoutePartReads: Reads[Route.RoutePart.RoadRoutePart] = (
     __.read[Route.RoutePart.BasicRoutePart] and
     (__ \ "road").readNullable[String] and
     (__ \ "turn").readNullable[String]
-  ) ((basic: Route.RoutePart.BasicRoutePart, road: Option[String], turn: Option[String]) =>
+  )( (basic: Route.RoutePart.BasicRoutePart, road: Option[String], turn: Option[String]) =>
       Route.RoutePart.RoadRoutePart(
         basic.id, basic.`type`, basic.mode, basic.directions, basic.distanceMeters, basic.travelTime, basic.coords,
         road, turn
       )
   )
 
-  val publicTransportRoutePartReads: Reads[Route.RoutePart.PublicTransportRoutePart] = (
-    __.read[Route.RoutePart.BasicRoutePart] and
-    (__ \ "line").read[String] and
-    (__ \ "departure_station").read[String] and
-    (__ \ "arrival_station").read[String] and
-    (__ \ "departs_at").read[String] and
-    (__ \ "arrives_at").read[String] and
-    (__ \ "num_stops").read[Int]
-  ) ((basic: Route.RoutePart.BasicRoutePart, line: String, departureStation: String, arrivalStation: String, departsAt: String, arrivesAt: String, numStops: Int) =>
-    Route.RoutePart.PublicTransportRoutePart(
-      basic.id, basic.`type`, basic.mode, basic.directions, basic.distanceMeters, basic.travelTime, basic.coords,
-      line, departureStation, arrivalStation, departsAt, arrivesAt, numStops
+    val publicTransportRoutePartReads: Reads[PublicTransportRoutePart] = (
+      __.read[Route.RoutePart.BasicRoutePart] and
+      (__ \ "line").read[String] and
+      (__ \ "departure_station").read[String] and
+      (__ \ "arrival_station").read[String] and
+      (__ \ "departs_at").read[String] and
+      (__ \ "arrives_at").read[String] and
+      (__ \ "num_stops").read[Int]
+    ) ((basic: Route.RoutePart.BasicRoutePart, line: String, departureStation: String, arrivalStation: String, departsAt: String, arrivesAt: String, numStops: Int) =>
+      PublicTransportRoutePart(
+          basic.id, basic.`type`, basic.mode, basic.directions, basic.distanceMeters, basic.travelTime, basic.coords,
+          line, departureStation, arrivalStation, departsAt, arrivesAt, numStops
+      )
     )
-  )
 
-  implicit val routePartReads: Reads[Route.RoutePart] = (__ \ "type").read[String].flatMap[Route.RoutePart] {
-    case "basic" => basicRoutePartReadsV4.map(_.asInstanceOf[Route.RoutePart])
-    case "start_end" => startEndRoutePartReadsV4.map(_.asInstanceOf[Route.RoutePart])
-    case "road" => roadRoutePartReadsV4.map(_.asInstanceOf[Route.RoutePart])
-    case "public_transport" => publicTransportRoutePartReads.map(_.asInstanceOf[Route.RoutePart])
-  }
+  implicit val routePartReads: Reads[RoutePart] =
+    (__ \ "type").read[String].flatMap {
+      case "basic"            => basicRoutePartReads.map(x => x: RoutePart)
+      case "start_end"        => startEndRoutePartReads.map(x => x: RoutePart)
+      case "road"             => roadRoutePartReads.map(x => x: RoutePart)
+      case "public_transport" => publicTransportRoutePartReads.map(x => x: RoutePart)
+    }
 
   implicit val routeReads: Reads[Route] = (
     (__ \ "departure_time").read[String] and
@@ -100,11 +104,11 @@ object CommonReads {
     (__ \ "parts").read[Seq[Route.RoutePart]]
   ) (Route.apply _)
 
-  implicit val timeFilterTravelTimeReads: Reads[TravelTime] = (
-    (__ \ "min").read[Int] and
-    (__ \ "max").read[Int] and
-    (__ \ "mean").read[Int] and
-    (__ \ "median").read[Int]
+  implicit val zoneTravelTimeReads: Reads[TravelTime] = (
+    (__ \ "min").read[FiniteDuration](secondsToFiniteDurationReads) and
+    (__ \ "max").read[FiniteDuration](secondsToFiniteDurationReads) and
+    (__ \ "mean").read[FiniteDuration](secondsToFiniteDurationReads) and
+    (__ \ "median").read[FiniteDuration](secondsToFiniteDurationReads)
   ) (TravelTime.apply _)
 
   implicit val timeFilterZonePropertiesReads: Reads[ZoneSearchProperties] = (

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/ErrorReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/ErrorReads.scala
@@ -5,13 +5,11 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{Reads, __}
 
 object ErrorReads {
-
-  implicit val requestErrorReads: Reads[TravelTimeSdkError.ErroResponseDetails] = (
+  implicit val requestErrorReads: Reads[TravelTimeSdkError.ErrorResponseDetails] = (
     (__ \ "http_status").read[Int] and
     (__ \ "error_code").read[Int] and
     (__ \ "description").read[String] and
     (__ \ "documentation_link").read[String] and
     (__ \ "additional_info").read[Map[String, Seq[String]]]
-  ) (TravelTimeSdkError.ErroResponseDetails.apply _)
-
+  ) (TravelTimeSdkError.ErrorResponseDetails.apply _)
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/GeoJsonReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/GeoJsonReads.scala
@@ -5,6 +5,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{Reads, __}
 
 object GeoJsonReads {
+
   def reads[A](propertyReads: Reads[A]): Reads[GeoJsonResponse[A]] = (__ \ "type").read[String].flatMap({
     case "FeatureCollection" => GeoJsonReads.readFeatureCollection(propertyReads).map(x => GeoJsonResponse(x))
     case "Feature" => GeoJsonReads.readSingleFeature(propertyReads).map(x =>GeoJsonResponse(x))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/GeocodingReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/GeocodingReads.scala
@@ -7,6 +7,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{Reads, __}
 
 object GeocodingReads  {
+
   private val propertyReads: Reads[GeocodingResponseProperties] = (
     (__ \ "name").read[String] and
     (__ \ "label").read[String] and
@@ -23,9 +24,8 @@ object GeocodingReads  {
     (__ \ "country_code").readNullable[String] and
     (__ \ "continent").readNullable[String] and
     (__ \ "postcode").readNullable[String] and
-    (__ \ "features").readNullable(mapInfoFeaturesReadsV4)
+    (__ \ "features").readNullable(mapInfoFeaturesReads)
   )(GeocodingResponseProperties.apply _)
 
   implicit val geocodingReads: Reads[GeoJsonResponse[GeocodingResponseProperties]] = GeoJsonReads.reads(propertyReads)
-
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/RoutesReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/RoutesReads.scala
@@ -8,6 +8,7 @@ import play.api.libs.json.{JsValue, Reads, __}
 import scala.concurrent.duration.FiniteDuration
 
 object RoutesReads {
+
   implicit val routePropertiesReads: Reads[RoutesResponse.Properties] = (
     (__ \ "travel_time").readNullable[FiniteDuration](secondsToFiniteDurationReads) and
     (__ \ "distance").readNullable[Int] and

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/TimeMapBoxesReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/TimeMapBoxesReads.scala
@@ -31,5 +31,4 @@ object TimeMapBoxesReads {
     (__ \ "results").read[Seq[TimeMapBoxesResponse.SingleSearchResult]] and
     __.read[JsValue]
   )(TimeMapBoxesResponse.apply _)
-
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/TimeMapReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/TimeMapReads.scala
@@ -8,6 +8,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsValue, Reads, __}
 
 object TimeMapReads {
+
   implicit val timeMapShapeReads: Reads[TimeMapResponse.Shape] = (
     (__ \ "shell").read[Seq[Coords]](Reads.seq(coordsReads)) and
     (__ \ "holes").read[Seq[Seq[Coords]]](Reads.seq(Reads.seq(coordsReads)))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/TimeMapWktReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/TimeMapWktReads.scala
@@ -18,5 +18,4 @@ object TimeMapWktReads {
     (__ \ "results").read[Seq[TimeMapWktResponse.SingleSearchResult]] and
     __.read[JsValue]
   )(TimeMapWktResponse.apply _)
-
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/timefilter/TimeFilterPostcodesReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/timefilter/TimeFilterPostcodesReads.scala
@@ -8,6 +8,7 @@ import com.igeolise.traveltimesdk.json.reads.CommonReads._
 import scala.concurrent.duration.FiniteDuration
 
 object TimeFilterPostcodesReads  {
+
   implicit val postcodesPropertiesReads: Reads[PostcodesProperties] = (
     (__ \ "travel_time").readNullable[FiniteDuration](secondsToFiniteDurationReads) and
     (__ \ "distance").readNullable[Int]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/timefilter/TimeFilterReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/timefilter/TimeFilterReads.scala
@@ -1,17 +1,30 @@
 package com.igeolise.traveltimesdk.json.reads.timefilter
 
-import com.igeolise.traveltimesdk.dto.responses.common.{Fares, Route}
+import com.igeolise.traveltimesdk.dto.responses.common.DistanceBreakdown.BreakdownPart
+import com.igeolise.traveltimesdk.dto.responses.common.{DistanceBreakdown, Fares, Route}
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterResponse
 import com.igeolise.traveltimesdk.json.reads.CommonReads._
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsValue, Reads, __}
+
 import scala.concurrent.duration.FiniteDuration
 
 object TimeFilterReads {
 
+  implicit val breakdownPartReads: Reads[BreakdownPart] = (
+    (__ \ "mode").read[String] and
+    (__ \ "distance").read[Int]
+  )(BreakdownPart.apply _)
+
+  val distanceBreakdownReads: Reads[Option[DistanceBreakdown]] =
+    (__ \ "distance_breakdown").readNullable[Seq[BreakdownPart]].map { maybeBreakdownParts =>
+      maybeBreakdownParts.map(DistanceBreakdown.apply)
+    }
+
   implicit val timeFilterPropertiesReads: Reads[TimeFilterResponse.Properties] = (
     (__ \ "travel_time").readNullable[FiniteDuration](secondsToFiniteDurationReads) and
     (__ \ "distance").readNullable[Int] and
+    distanceBreakdownReads and
     (__ \ "fares").readNullable[Fares] and
     (__ \ "route").readNullable[Route]
   )(TimeFilterResponse.Properties.apply _)

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/timefilter/TimeFilterSectorsReads.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/reads/timefilter/TimeFilterSectorsReads.scala
@@ -18,5 +18,4 @@ object TimeFilterSectorsReads  {
     (__ \ "results").read[Seq[TimeFilterSectorsResponse.SingleSearchResult]] and
     __.read[JsValue]
   )(TimeFilterSectorsResponse.apply _)
-
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/CommonWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/CommonWrites.scala
@@ -24,7 +24,7 @@ object CommonWrites {
     def toSeconds: Option[Int] = self.map(time => time.toSeconds.toInt)
   }
 
-  val secondsToFiniteDurationWrites: Writes[FiniteDuration] = Writes.IntWrites.contramap(_.toSeconds.toInt)
+  val finiteDurationToSecondsWrites: Writes[FiniteDuration] = Writes.IntWrites.contramap(_.toSeconds.toInt)
 
   implicit class formatDate(self: ZonedDateTime) {
     val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
@@ -39,12 +39,12 @@ object CommonWrites {
   implicit val fullRangeParamsWrites: Writes[FullRangeParams] = (
     (__ \ "enabled").write[Boolean] and
     (__ \ "max_results").write[Int] and
-    (__ \ "width").write[Int]
+    (__ \ "width").write[FiniteDuration](finiteDurationToSecondsWrites)
   ) (unlift(FullRangeParams.unapply))
 
   implicit val rangeParamsWrites: Writes[RangeParams] = (
     (__ \ "enabled").write[Boolean] and
-    (__ \ "width").write[Int]
+    (__ \ "width").write[FiniteDuration](finiteDurationToSecondsWrites)
   ) (unlift(RangeParams.unapply))
 
   implicit val publicTransportWrites: Writes[PublicTransportation] = (
@@ -116,7 +116,7 @@ object CommonWrites {
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[Transportation] and
     (__ \ "arrival_time").write[String] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "reachable_postcodes_threshold").write[Double] and
     (__ \ "properties").write[Seq[TimeFilterZonesProperty]] and
     (__ \ "range").writeNullable[FullRangeParams]
@@ -127,7 +127,7 @@ object CommonWrites {
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[Transportation] and
     (__ \ "departure_time").write[String] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "reachable_postcodes_threshold").write[Double] and
     (__ \ "properties").write[Seq[TimeFilterZonesProperty]] and
     (__ \ "range").writeNullable[FullRangeParams]

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/CommonWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/CommonWrites.scala
@@ -2,13 +2,16 @@ package com.igeolise.traveltimesdk.json.writes
 
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+
 import com.igeolise.traveltimesdk.dto.common.Coords
 import com.igeolise.traveltimesdk.dto.common.ZoneSearches.{ArrivalSearch, DepartureSearch}
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.{PropertyType, TimeFilterZonesProperty}
-import com.igeolise.traveltimesdk.dto.requests.common.{FerryTransportation, Location, PublicTransportation, Transportation}
+import com.igeolise.traveltimesdk.dto.requests.common._
 import com.igeolise.traveltimesdk.dto.requests.common.RangeParams.{FullRangeParams, RangeParams}
+import com.igeolise.traveltimesdk.dto.requests.common.Transportation.{CyclingPublicTransport, Driving, DrivingPublicTransport, PublicTransport}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+
 import scala.concurrent.duration.FiniteDuration
 
 object CommonWrites {
@@ -27,6 +30,9 @@ object CommonWrites {
     val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
     def formatDate: String = self.format(dateFormatter)
   }
+
+  def parameterlessTransportationJson(transportation: Transportation): JsObject =
+     JsObject(Seq("type" -> Json.toJson(transportation.transportType)))
 
   implicit val formattedDateWrites: Writes[ZonedDateTime] = Writes.StringWrites.contramap(_.formatDate)
 
@@ -71,11 +77,28 @@ object CommonWrites {
     (__ \ "boarding_time").writeNullable[Int]
   ) ((m: FerryTransportation) => (m.transportType, m.parameters.boardingTime.toSeconds))
 
+  implicit val cyclingPublicTransportWrites: Writes[CyclingPublicTransport] = (
+    (__ \ "type").write[String] and
+    (__ \ "cycling_time_to_station").writeNullable[Int] and
+    (__ \ "parking_time").writeNullable[Int] and
+    (__ \ "boarding_time").writeNullable[Int]
+  ) ((m: CyclingPublicTransport) => (
+      m.transportType,
+      m.params.cyclingToStationTime.toSeconds,
+      m.params.parkingTime.toSeconds,
+      m.params.boardingTime.toSeconds
+    )
+  )
+
+  implicit val commonTransportationWrites: Writes[CommonTransportation] = Writes[CommonTransportation] {
+    case c: CyclingPublicTransport => cyclingPublicTransportWrites.writes(c)
+    case c: CommonTransportation => parameterlessTransportationJson(c)
+  }
+
   implicit val transportationWrites: Writes[Transportation] = Writes[Transportation] {
     case m: PublicTransportation => publicTransportWrites.writes(m)
-    case m: Transportation.DrivingTrain => drivingTrainWrites.writes(m)
-    case m: FerryTransportation => ferryWrites.writes(m)
-    case m: Transportation => JsObject(Seq("type" -> Json.toJson(m.transportType)))
+    case m: CommonTransportation => commonTransportationWrites.writes(m)
+    case m: Transportation => parameterlessTransportationJson(m)
   }
 
   implicit val coordsWrites: Writes[Coords] = (

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/TimeMapWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/TimeMapWrites.scala
@@ -19,7 +19,7 @@ object TimeMapWrites {
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[Transportation] and
     (__ \ "departure_time").write[ZonedDateTime] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "range").writeNullable[RangeParams] and
     (__ \ "properties").writeNullable[Seq[TimeMapRequestProperty]]
   ) (unlift(DepartureSearch.unapply))
@@ -29,7 +29,7 @@ object TimeMapWrites {
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[Transportation] and
     (__ \ "arrival_time").write[ZonedDateTime] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "range").writeNullable[RangeParams] and
     (__ \ "properties").writeNullable[Seq[TimeMapRequestProperty]]
   ) (unlift(ArrivalSearch.unapply))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/timefilter/TimeFilterFastWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/timefilter/TimeFilterFastWrites.scala
@@ -18,7 +18,7 @@ object TimeFilterFastWrites {
     (__ \ "departure_location_id").write[String] and
     (__ \ "arrival_location_ids").write[Seq[String]] and
     (__ \ "transportation").write[TimeFilterFastTransportation] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "arrival_time_period").write[ArrivalTimePeriod] and
     (__ \ "properties").write[Seq[TimeFilterFastProperty]]
   )(unlift(OneToMany.unapply))
@@ -28,7 +28,7 @@ object TimeFilterFastWrites {
     (__ \ "arrival_location_id").write[String] and
     (__ \ "departure_location_ids").write[Seq[String]] and
     (__ \ "transportation").write[TimeFilterFastTransportation] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "arrival_time_period").write[ArrivalTimePeriod] and
     (__ \ "properties").write[Seq[TimeFilterFastProperty]]
   )(unlift(ManyToOne.unapply))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/timefilter/TimeFilterPostcodesWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/timefilter/TimeFilterPostcodesWrites.scala
@@ -18,7 +18,7 @@ object TimeFilterPostcodesWrites {
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[Transportation] and
     (__ \ "departure_time").write[String] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "range").writeNullable[FullRangeParams] and
     (__ \ "properties").write[Seq[TimeFilterPostcodesProperty]]
   )(unlift(DepartureSearch.unapply))
@@ -28,7 +28,7 @@ object TimeFilterPostcodesWrites {
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[Transportation] and
     (__ \ "arrival_time").write[String] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "range").writeNullable[FullRangeParams] and
     (__ \ "properties").write[Seq[TimeFilterPostcodesProperty]]
   )(unlift(ArrivalSearch.unapply))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/timefilter/TimeFilterWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/timefilter/TimeFilterWrites.scala
@@ -18,7 +18,7 @@ object TimeFilterWrites{
     (__ \ "departure_location_ids").write[Seq[String]] and
     (__ \ "arrival_location_id").write[String] and
     (__ \ "transportation").write[Transportation] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "arrival_time").write[ZonedDateTime] and
     (__ \ "range").writeNullable[FullRangeParams] and
     (__ \ "properties").write[Seq[TimeFilterRequestProperty]]
@@ -29,7 +29,7 @@ object TimeFilterWrites{
     (__ \ "departure_location_id").write[String] and
     (__ \ "arrival_location_ids").write[Seq[String]] and
     (__ \ "transportation").write[Transportation] and
-    (__ \ "travel_time").write[FiniteDuration](secondsToFiniteDurationWrites) and
+    (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "departure_time").write[ZonedDateTime] and
     (__ \ "range").writeNullable[FullRangeParams] and
     (__ \ "properties").write[Seq[TimeFilterRequestProperty]]

--- a/shared/src/test/resources/json/TimeFilter/request/timeFilterRequest-cycling-pt.json
+++ b/shared/src/test/resources/json/TimeFilter/request/timeFilterRequest-cycling-pt.json
@@ -1,0 +1,75 @@
+{
+  "locations": [
+    {
+      "id": "Musee Du Cannabis",
+      "coords": {
+        "lat": 52.37213452952525,
+        "lng": 4.897260664233954
+      }
+    },
+    {
+      "id": "Amsterdam center",
+      "coords": {
+        "lat": 52.3680,
+        "lng": 4.9036
+      }
+    },
+    {
+      "id": "Science Museum",
+      "coords": {
+        "lat": 52.37421715421411,
+        "lng": 4.912337064743042
+      }
+    }
+  ],
+  "departure_searches": [
+    {
+      "id": "forward search example",
+      "departure_location_id": "Amsterdam center",
+      "arrival_location_ids": [
+        "Musee Du Cannabis",
+        "Science Museum"
+      ],
+      "transportation": {
+        "type": "cycling+public_transport",
+        "cycling_time_to_station": 300,
+        "parking_time": 600,
+        "boarding_time": 900
+      },
+      "travel_time": 1800,
+      "departure_time": "2019-07-08T08:00:00Z",
+      "range": {
+        "enabled": true,
+        "max_results": 3,
+        "width": 600
+      },
+      "properties": [
+        "travel_time"
+      ]
+    }
+  ],
+  "arrival_searches": [
+    {
+      "id": "backward search example",
+      "departure_location_ids": [
+        "Musee Du Cannabis",
+        "Science Museum"
+      ],
+      "arrival_location_id": "Amsterdam center",
+      "transportation": {
+        "type": "cycling+public_transport",
+        "cycling_time_to_station": 300,
+        "parking_time": 600,
+        "boarding_time": 900
+      },
+      "arrival_time": "2019-07-08T08:00:00Z",
+      "travel_time": 1900,
+      "properties": [
+        "travel_time",
+        "distance",
+        "distance_breakdown",
+        "fares"
+      ]
+    }
+  ]
+}

--- a/shared/src/test/resources/json/TimeFilter/response/timeFilterResponse-distance-breakdown.json
+++ b/shared/src/test/resources/json/TimeFilter/response/timeFilterResponse-distance-breakdown.json
@@ -1,0 +1,37 @@
+{
+  "results": [
+    {
+      "search_id": "backward search example",
+      "locations": [
+        {
+          "id": "Hyde Park",
+          "properties": [
+            {
+              "distance_breakdown": [
+                {
+                  "mode": "bus",
+                  "distance": 1786
+                },
+                {
+                  "mode": "walk",
+                  "distance": 1256
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "unreachable": [
+        "ZSL London Zoo"
+      ]
+    },
+    {
+      "search_id": "forward search example",
+      "locations": [],
+      "unreachable": [
+        "Hyde Park",
+        "ZSL London Zoo"
+      ]
+    }
+  ]
+}

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/reads/MapInfoReadsTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/reads/MapInfoReadsTest.scala
@@ -6,10 +6,11 @@ import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.responses.MapInfoResponse
 import com.igeolise.traveltimesdk.dto.responses.MapInfoResponse._
 import com.igeolise.traveltimesdk.json.reads.AvailableDataReads._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsSuccess, Json}
 
-class MapInfoReadsTest extends FunSpec with Matchers {
+class MapInfoReadsTest extends AnyFunSpec with Matchers {
 
   it("Testing mapInfo response + ZonedDateTime") {
     val json =
@@ -40,5 +41,4 @@ class MapInfoReadsTest extends FunSpec with Matchers {
       Json.parse(json)
     )
   }
-
 }

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/reads/SupportedLocationsTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/reads/SupportedLocationsTest.scala
@@ -1,13 +1,14 @@
 package com.igeolise.traveltimesdk.reads
 
 import com.igeolise.traveltimesdk.TestUtils
-import com.igeolise.traveltimesdk.json.reads.AvailableDataReads._
 import com.igeolise.traveltimesdk.dto.responses.SupportedLocationsResponse
 import com.igeolise.traveltimesdk.dto.responses.SupportedLocationsResponse.Location
-import org.scalatest.{FunSpec, Matchers}
+import com.igeolise.traveltimesdk.json.reads.AvailableDataReads._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsSuccess, Json}
 
-class SupportedLocationsTest extends FunSpec with Matchers {
+class SupportedLocationsTest extends AnyFunSpec with Matchers {
 
   it("parse departurePostcodesResponse response") {
     val json =

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeFilterPostcodesReadsTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeFilterPostcodesReadsTest.scala
@@ -4,12 +4,13 @@ import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterPostcodesResponse
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterPostcodesResponse.{Postcode, PostcodesProperties, SingleSearchResult}
 import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterPostcodesReads._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsSuccess, Json}
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.SECONDS
 
-class TimeFilterPostcodesReadsTest extends FunSpec with Matchers {
+import scala.concurrent.duration.{Duration, SECONDS}
+
+class TimeFilterPostcodesReadsTest extends AnyFunSpec with Matchers {
 
   it("parse departurePostcodesResponse response") {
     val json =

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeFilterReadsTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeFilterReadsTest.scala
@@ -1,17 +1,21 @@
 package com.igeolise.traveltimesdk.reads
 
-import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterReads._
+import com.igeolise.traveltimesdk.TestUtils._
+import com.igeolise.traveltimesdk.dto.responses.common.DistanceBreakdown
+import com.igeolise.traveltimesdk.dto.responses.common.DistanceBreakdown.BreakdownPart
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterResponse
 import com.igeolise.traveltimesdk.dto.responses.timefilter.TimeFilterResponse.{Location, Properties, SingleSearchResult}
-import com.igeolise.traveltimesdk.TestUtils
-import org.scalatest.{FunSpec, Matchers}
+import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterReads._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsSuccess, Json}
+
 import scala.concurrent.duration._
 
-class TimeFilterReadsTest extends FunSpec with Matchers {
+class TimeFilterReadsTest extends AnyFunSpec with Matchers {
 
   it("parse forward_search response") {
-    val json = TestUtils.resource("shared/src/test/resources/json/TimeFilter/response/timeFilterResponse.json")
+    val json = resource("shared/src/test/resources/json/TimeFilter/response/timeFilterResponse.json")
     val result = Json.parse(json).validate[TimeFilterResponse]
 
     result shouldBe a [JsSuccess[_]]
@@ -39,4 +43,42 @@ class TimeFilterReadsTest extends FunSpec with Matchers {
     )
   }
 
+  it("parse response with a distance_breakdown parameter set") {
+    val jsonSource = resource("shared/src/test/resources/json/TimeFilter/response/timeFilterResponse-distance-breakdown.json")
+    val parseResult = Json.parse(jsonSource).validate[TimeFilterResponse]
+    val expectedResult = TimeFilterResponse(
+      Seq(
+        SingleSearchResult(
+          "backward search example",
+          Seq(
+            Location(
+              "Hyde Park",
+              Seq(
+                Properties(
+                  None,
+                  None,
+                  Some( DistanceBreakdown(Seq(BreakdownPart("bus", 1786), BreakdownPart("walk", 1256))) )
+                )
+              )
+            )
+          ),
+          Seq("ZSL London Zoo")
+        ),
+        SingleSearchResult(
+          "forward search example",
+          Seq.empty[Location],
+          Seq("Hyde Park", "ZSL London Zoo")
+        )
+      ),
+
+      Json.parse(jsonSource)
+    )
+
+    parseResult shouldBe a [JsSuccess[_]]
+
+    println(expectedResult)
+    println(parseResult.get)
+
+    expectedResult shouldBe parseResult.get
+  }
 }

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeFilterZonesReadsTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeFilterZonesReadsTest.scala
@@ -1,14 +1,18 @@
 package com.igeolise.traveltimesdk.reads
 
-import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterSectorsReads._
-import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterDistrictsReads._
-import com.igeolise.traveltimesdk.dto.responses.timefilter.{TimeFilterDistrictsResponse, TimeFilterSectorsResponse}
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.{TravelTime, Zone, ZoneSearchProperties}
-import org.scalatest.{FunSpec, Matchers}
+import com.igeolise.traveltimesdk.dto.responses.timefilter.{TimeFilterDistrictsResponse, TimeFilterSectorsResponse}
+import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterDistrictsReads._
+import com.igeolise.traveltimesdk.json.reads.timefilter.TimeFilterSectorsReads._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsSuccess, Json}
 
-class TimeFilterZonesReadsTest extends FunSpec with Matchers {
+import scala.concurrent.duration._
+
+class TimeFilterZonesReadsTest extends AnyFunSpec with Matchers {
+
   it("parse districts arrivals response") {
     val json = TestUtils.resource("shared/src/test/resources/json/TimeFilterDistricts/response/DistrictsResponse.json")
     val result = Json.parse(json).validate[TimeFilterDistrictsResponse]
@@ -23,16 +27,16 @@ class TimeFilterZonesReadsTest extends FunSpec with Matchers {
             Zone(
               "wc2n",
               ZoneSearchProperties(
-                Some(TravelTime(10,199,142,164)),
-                Some(TravelTime(10,527,324,397)),
+                Some(TravelTime(10.seconds, 199.seconds, 142.seconds, 164.seconds)),
+                Some(TravelTime(10.seconds, 527.seconds, 324.seconds, 397.seconds)),
                 Some(12.571428571428573)
               )
             ),
             Zone(
               "sw1a",
               ZoneSearchProperties(
-                Some(TravelTime(86,194,147,155)),
-                Some(TravelTime(86,645,379,396)),
+                Some(TravelTime(86.seconds, 194.seconds, 147.seconds, 155.seconds)),
+                Some(TravelTime(86.seconds, 645.seconds, 379.seconds, 396.seconds)),
                 Some(12.418300653594772)
               )
             )
@@ -57,8 +61,8 @@ class TimeFilterZonesReadsTest extends FunSpec with Matchers {
             Zone(
               "wc2n5",
               ZoneSearchProperties(
-                Some(TravelTime(10,113,78,81)),
-                Some(TravelTime(10,113,78,81)),
+                Some(TravelTime(10.seconds, 113.seconds, 78.seconds, 81.seconds)),
+                Some(TravelTime(10.seconds, 113.seconds, 78.seconds, 81.seconds)),
                 Some(15.217391304347828)
               )
             )

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeMapReadsTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/reads/TimeMapReadsTest.scala
@@ -7,13 +7,13 @@ import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.Coords
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.TimeMapProps.TimeMapResponseProperties
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.{JsSuccess, Json}
 
-class TimeMapReadsTest extends FunSpec with Matchers {
+class TimeMapReadsTest extends AnyFunSpec with Matchers {
 
   it("parse departure_searches response") {
     val json = TestUtils.resource("shared/src/test/resources/json/TimeMap/response/timeMapResponse-NoJoints.json")
-//    val emptyjson = resource("src/test/resources/json/TimeMap/response/emptyResponse.json")
     val result = Json.parse(json).validate[TimeMapResponse]
 
     result shouldBe a [JsSuccess[_]]

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/RoutesWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/RoutesWritesTest.scala
@@ -14,6 +14,7 @@ import com.igeolise.traveltimesdk.json.writes.RoutesWrites._
 import org.scalatest.Matchers
 import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json
+import scala.concurrent.duration._
 
 class RoutesWritesTest extends AnyFunSpec with Matchers {
 
@@ -42,7 +43,7 @@ class RoutesWritesTest extends AnyFunSpec with Matchers {
       Transportation.PublicTransport(PublicTransportationParams()),
       time,
       Seq(TravelTime, Distance, Route, Fares),
-      Some(FullRangeParams(enabled = true, 1, 1800))
+      Some(FullRangeParams(enabled = true, 1, 30.minutes))
     )
 
     val routesRequest = RoutesRequest(locations, Seq(routesDepartures), Seq(routesArrivals))

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/RoutesWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/RoutesWritesTest.scala
@@ -2,19 +2,21 @@ package com.igeolise.traveltimesdk.writes
 
 import java.time.{ZoneId, ZonedDateTime}
 
-import com.igeolise.traveltimesdk.json.writes.RoutesWrites._
-import com.igeolise.traveltimesdk.dto.requests.RoutesRequest
-import com.igeolise.traveltimesdk.dto.requests.RoutesRequest.{ArrivalSearch, DepartureSearch}
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.Coords
+import com.igeolise.traveltimesdk.dto.requests.RoutesRequest
+import com.igeolise.traveltimesdk.dto.requests.RoutesRequest.{ArrivalSearch, DepartureSearch}
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType
-import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{distance, fares, route, travelTime}
+import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{Distance, Fares, Route, TravelTime}
 import com.igeolise.traveltimesdk.dto.requests.common.RangeParams.FullRangeParams
 import com.igeolise.traveltimesdk.dto.requests.common.{Location, PublicTransportationParams, Transportation}
-import org.scalatest.{FunSpec, Matchers}
+import com.igeolise.traveltimesdk.json.writes.RoutesWrites._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json
 
-class RoutesWritesTest extends FunSpec with Matchers {
+class RoutesWritesTest extends AnyFunSpec with Matchers {
+
   it("departure and arrival searches for Routes") {
     val locations: Seq[Location] = Seq(
       Location("London center", Coords(51.508930, -0.131387)),
@@ -29,7 +31,7 @@ class RoutesWritesTest extends FunSpec with Matchers {
       Seq("Hyde Park", "ZSL London Zoo"),
       Transportation.Driving,
       time,
-      Seq(PropertyType.travelTime, distance, route),
+      Seq(PropertyType.TravelTime, Distance, Route),
       None
     )
 
@@ -39,7 +41,7 @@ class RoutesWritesTest extends FunSpec with Matchers {
       "London center",
       Transportation.PublicTransport(PublicTransportationParams()),
       time,
-      Seq(travelTime, distance, route, fares),
+      Seq(TravelTime, Distance, Route, Fares),
       Some(FullRangeParams(enabled = true, 1, 1800))
     )
 

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterPostcodesWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterPostcodesWritesTest.scala
@@ -1,18 +1,18 @@
 package com.igeolise.traveltimesdk.writes
 
-import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterPostcodesWrites._
-import com.igeolise.traveltimesdk.dto.requests.timefilter.TimeFilterPostcodesRequest
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.Coords
-import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{distance, travelTime}
+import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{Distance, TravelTime}
 import com.igeolise.traveltimesdk.dto.requests.common.PublicTransportationParams
 import com.igeolise.traveltimesdk.dto.requests.common.Transportation.PublicTransport
-import org.scalatest.{FunSpec, Matchers}
+import com.igeolise.traveltimesdk.dto.requests.timefilter.TimeFilterPostcodesRequest
+import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterPostcodesWrites._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json
 import scala.concurrent.duration._
 
-class TimeFilterPostcodesWritesTest
-  extends FunSpec with Matchers  {
+class TimeFilterPostcodesWritesTest extends AnyFunSpec with Matchers  {
 
   it("departure_searches for TimeFilter Postcodes") {
     val transport = PublicTransport(PublicTransportationParams(None, None))
@@ -24,7 +24,7 @@ class TimeFilterPostcodesWritesTest
         "2018-09-27T08:00:00Z",
         Duration(1800, SECONDS),
         None,
-        Seq(travelTime, distance)
+        Seq(TravelTime, Distance)
       )
     val postcodesArrival : TimeFilterPostcodesRequest.ArrivalSearch =
       TimeFilterPostcodesRequest.ArrivalSearch(
@@ -34,7 +34,7 @@ class TimeFilterPostcodesWritesTest
         "2018-09-27T08:00:00Z",
         Duration(1800, SECONDS),
         None,
-        Seq(travelTime, distance)
+        Seq(TravelTime, Distance)
       )
     val postcodesRequest = TimeFilterPostcodesRequest(Seq(postcodesDeparture), Seq(postcodesArrival))
 
@@ -43,6 +43,4 @@ class TimeFilterPostcodesWritesTest
 
     timeFilterJson should equal (Json.parse(jsonResource))
   }
-
-
 }

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterWritesTest.scala
@@ -1,19 +1,27 @@
 package com.igeolise.traveltimesdk.writes
 
 import java.time.{ZoneId, ZonedDateTime}
-import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterWrites._
-import com.igeolise.traveltimesdk.dto.requests.timefilter.TimeFilterRequest
-import com.igeolise.traveltimesdk.dto.requests.timefilter.TimeFilterRequest.DepartureSearch
+
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.Coords
-import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{distance, distanceBreakdown, fares, travelTime}
+import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{Distance, DistanceBreakdown, Fares, TravelTime}
 import com.igeolise.traveltimesdk.dto.requests.common.RangeParams.FullRangeParams
-import com.igeolise.traveltimesdk.dto.requests.common.{CommonProperties, Location, PublicTransportationParams, Transportation}
-import org.scalatest.{FunSpec, Matchers}
-import play.api.libs.json.Json
+import com.igeolise.traveltimesdk.dto.requests.common.Transportation.{CyclingPublicTransport, PublicTransport}
+import com.igeolise.traveltimesdk.dto.requests.common.Transportation.PublicTransport.Bus
+import com.igeolise.traveltimesdk.dto.requests.common.{CommonProperties, CyclingPublicTransportParams, Location, PublicTransportationParams}
+import com.igeolise.traveltimesdk.dto.requests.timefilter.TimeFilterRequest
+import com.igeolise.traveltimesdk.dto.requests.timefilter.TimeFilterRequest.DepartureSearch
+import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterWrites._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
+import play.api.libs.json.{JsValue, Json}
+
+import scala.concurrent.duration._
+import cats.syntax.option._
+
 import scala.concurrent.duration.{Duration, SECONDS}
 
-class TimeFilterWritesTest extends FunSpec with Matchers {
+class TimeFilterWritesTest extends AnyFunSpec with Matchers {
   it("TimeFilterWritesTest: locations, departure_searches and arrival_searches json request") {
     val locations: Seq[Location] = Seq(
       Location("London center", Coords(51.508930, -0.131387)),
@@ -27,22 +35,22 @@ class TimeFilterWritesTest extends FunSpec with Matchers {
       "forward search example",
       "London center",
       Seq("Hyde Park", "ZSL London Zoo" ),
-      Transportation.Bus(PublicTransportationParams(None, None)),
+      Bus(PublicTransportationParams(None, None)),
       Duration(1800, SECONDS),
       time,
       Some(FullRangeParams(enabled = true, 3, 600)),
-      Seq(CommonProperties.PropertyType.travelTime)
+      Seq(CommonProperties.PropertyType.TravelTime)
     )
 
     val timeFilterArrivals = TimeFilterRequest.ArrivalSearch(
       "backward search example",
       Seq("Hyde Park", "ZSL London Zoo"),
       "London center",
-      Transportation.PublicTransport(PublicTransportationParams(None, None)),
+      PublicTransport(PublicTransportationParams(None, None)),
       Duration(1900, SECONDS),
       time,
       None,
-      Seq(travelTime, distance, distanceBreakdown, fares)
+      Seq(TravelTime, Distance, DistanceBreakdown, Fares)
     )
 
     val jsonResource = TestUtils.resource("shared/src/test/resources/json/TimeFilter/request/timeFilterRequest.json")
@@ -50,5 +58,45 @@ class TimeFilterWritesTest extends FunSpec with Matchers {
     val timeFilterJson = Json.toJson(timeFilterRequest)
 
     timeFilterJson should equal (Json.parse(jsonResource))
+  }
+
+  it("Make json request for time-filter request with cycling+public_transport transportation") {
+      val locations: Seq[Location] = Seq(
+        Location("Musee Du Cannabis", Coords(52.37213452952525, 4.897260664233954)),
+        Location("Amsterdam center", Coords(52.3680, 4.9036)),
+        Location("Science Museum", Coords(52.37421715421411, 4.912337064743042))
+      )
+
+      val time = ZonedDateTime.of(2019,7,8,8,0,0,0,ZoneId.systemDefault())
+
+      val timeFilterDepartures = DepartureSearch(
+        "forward search example",
+        "Amsterdam center",
+        Seq("Musee Du Cannabis", "Science Museum"),
+        CyclingPublicTransport(CyclingPublicTransportParams(5.minutes.some, 10.minutes.some, 15.minutes.some)),
+        Duration(1800, SECONDS),
+        time,
+        Some(FullRangeParams(enabled = true, 3, 600)),
+        Seq(CommonProperties.PropertyType.TravelTime)
+      )
+
+      val timeFilterArrivals = TimeFilterRequest.ArrivalSearch(
+        "backward search example",
+        Seq("Musee Du Cannabis", "Science Museum"),
+        "Amsterdam center",
+        CyclingPublicTransport(CyclingPublicTransportParams(5.minutes.some, 10.minutes.some, 15.minutes.some)),
+        Duration(1900, SECONDS),
+        time,
+        None,
+        Seq(TravelTime, Distance, DistanceBreakdown, Fares)
+      )
+
+      val jsonResource = TestUtils.resource("shared/src/test/resources/json/TimeFilter/request/timeFilterRequest-cycling-pt.json")
+
+      val timeFilterRequest = TimeFilterRequest(locations, Seq(timeFilterDepartures), Seq(timeFilterArrivals))
+      val timeFilterJson: JsValue = Json.toJson(timeFilterRequest)
+      val parsed: JsValue = Json.parse(jsonResource)
+
+      timeFilterJson shouldBe parsed
   }
 }

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterWritesTest.scala
@@ -38,7 +38,7 @@ class TimeFilterWritesTest extends AnyFunSpec with Matchers {
       Bus(PublicTransportationParams(None, None)),
       Duration(1800, SECONDS),
       time,
-      Some(FullRangeParams(enabled = true, 3, 600)),
+      Some(FullRangeParams(enabled = true, 3, 10.minutes)),
       Seq(CommonProperties.PropertyType.TravelTime)
     )
 
@@ -76,7 +76,7 @@ class TimeFilterWritesTest extends AnyFunSpec with Matchers {
         CyclingPublicTransport(CyclingPublicTransportParams(5.minutes.some, 10.minutes.some, 15.minutes.some)),
         Duration(1800, SECONDS),
         time,
-        Some(FullRangeParams(enabled = true, 3, 600)),
+        Some(FullRangeParams(enabled = true, 3, 10.minutes)),
         Seq(CommonProperties.PropertyType.TravelTime)
       )
 

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterZonesWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterZonesWritesTest.scala
@@ -1,18 +1,19 @@
 package com.igeolise.traveltimesdk.writes
 
-import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterSectorsWrites._
-import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterDistrictsWrites._
-import com.igeolise.traveltimesdk.dto.requests.timefilter.{TimeFilterDistrictsRequest, TimeFilterSectorsRequest}
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.{Coords, ZoneSearches}
-import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{coverage, travelTimeAll, travelTimeReachable}
+import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{Coverage, TravelTimeAll, TravelTimeReachable}
 import com.igeolise.traveltimesdk.dto.requests.common.{PublicTransportationParams, Transportation}
-import org.scalatest.{FunSpec, Matchers}
+import com.igeolise.traveltimesdk.dto.requests.timefilter.{TimeFilterDistrictsRequest, TimeFilterSectorsRequest}
+import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterDistrictsWrites._
+import com.igeolise.traveltimesdk.json.writes.timefilter.TimeFilterSectorsWrites._
+import org.scalatest.Matchers
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json
+
 import scala.concurrent.duration._
 
-class TimeFilterZonesWritesTest
-  extends FunSpec with Matchers  {
+class TimeFilterZonesWritesTest extends AnyFunSpec with Matchers  {
   val departures = ZoneSearches.DepartureSearch(
     "public transport from Trafalgar Square",
     Coords(51.507609, -0.128315),
@@ -21,7 +22,7 @@ class TimeFilterZonesWritesTest
     Duration(1800, SECONDS),
     0.1,
     Seq(
-      coverage, travelTimeReachable, travelTimeAll
+      Coverage, TravelTimeReachable, TravelTimeAll
     )
   )
 
@@ -33,7 +34,7 @@ class TimeFilterZonesWritesTest
     Duration(1800, SECONDS),
     0.1,
     Seq(
-      coverage, travelTimeReachable, travelTimeAll
+      Coverage, TravelTimeReachable, TravelTimeAll
     )
   )
 

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeMapWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeMapWritesTest.scala
@@ -1,6 +1,7 @@
 package com.igeolise.traveltimesdk.writes
 
 import java.time.{ZoneId, ZonedDateTime}
+
 import com.igeolise.traveltimesdk.json.writes.TimeMapWrites._
 import com.igeolise.traveltimesdk.dto.requests.TimeMapRequest.ArrivalSearch
 import com.igeolise.traveltimesdk.dto.requests.TimeMapRequest
@@ -10,10 +11,12 @@ import com.igeolise.traveltimesdk.dto.requests.common.PublicTransportationParams
 import com.igeolise.traveltimesdk.dto.requests.common.RangeParams.RangeParams
 import com.igeolise.traveltimesdk.dto.requests.common.Transportation.PublicTransport
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
 import play.api.libs.json.Json
+
 import scala.concurrent.duration._
 
-class TimeMapWritesTest extends FunSpec with Matchers{
+class TimeMapWritesTest extends AnyFunSpec with Matchers{
 
   it("departure_searches and arrival_searches json request") {
     val trans = PublicTransport(PublicTransportationParams(Some(Duration(1, MINUTES)), None))

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeMapWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeMapWritesTest.scala
@@ -40,7 +40,7 @@ class TimeMapWritesTest extends AnyFunSpec with Matchers{
         Duration(900, SECONDS),
         Some(RangeParams(
           enabled = true,
-          3600
+          1.hour
         )),
         None,
       )


### PR DESCRIPTION
* Add: Scala 2.13.0 version support
* Add: `cycling+public_transport` transport type support added
* Add: type bounds for `TravelTimePlatformRequest` inner type - it has to be subtype of TravelTimePlatformResponse now
* Add: distance breakdown response property is now supported
* Add: tests for distance breakdown and `cycling+public_transport`
* Change: default backend for JVM project changed to `OkHttpFutureBackend`
* Change: `TravelTime` for Time Filter postcode sectors and districts are now `FiniteDuration` instead of `Int`
* Refactor: naming and structure
* Bump: Dependency versions