### PR TITLE
Fixed `java.ZonedDateTime` JSON formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val commonSettings = Seq(
   organization := "com.igeolise",
   bintrayOrganization := Some("igeolise"),
   name := "traveltime-platform-sdk",
-  version := "1.5.0",
+  version := "1.6.0",
   crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
   scalacOptions ++= Seq(
     "-deprecation",
@@ -18,11 +18,11 @@ val commonSettings = Seq(
     "-Ywarn-dead-code"
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "cats-core" % "2.0.0-M4",
-    "com.softwaremill.sttp" %%% "core" % "1.6.0",
-    "com.typesafe.play" %%% "play-json" % "2.7.4",
-    "com.beachape" %%% "enumeratum" % "1.5.13",
-    "org.scalatest" %% "scalatest" % "3.1.0-SNAP13" % Test,
+    "org.typelevel"         %%% "cats-core"  % "2.0.0-M4",
+    "com.softwaremill.sttp" %%% "core"       % "1.6.0",
+    "com.typesafe.play"     %%% "play-json"  % "2.7.4",
+    "com.beachape"          %%% "enumeratum" % "1.5.13",
+    "org.scalatest"         %%  "scalatest"  % "3.1.0-SNAP13" % Test,
   ),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 )

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/common/Zone.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/common/Zone.scala
@@ -1,5 +1,7 @@
 package com.igeolise.traveltimesdk.dto.common
 
+import java.time.ZonedDateTime
+
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.TimeFilterZonesProperty
 import com.igeolise.traveltimesdk.dto.requests.common.RangeParams.FullRangeParams
 import com.igeolise.traveltimesdk.dto.requests.common.Transportation
@@ -30,7 +32,7 @@ object ZoneSearches{
     id: String,
     coords: Coords,
     transportation: CommonTransportation,
-    departureTime: String,
+    departureTime: ZonedDateTime,
     travelTime: FiniteDuration,
     reachablePostcodesThreshold: Double,
     properties: Seq[TimeFilterZonesProperty],
@@ -41,7 +43,7 @@ object ZoneSearches{
     id: String,
     coords: Coords,
     transportation: CommonTransportation,
-    arrivalTime: String,
+    arrivalTime: ZonedDateTime,
     travelTime: FiniteDuration,
     reachablePostcodesThreshold: Double,
     properties: Seq[TimeFilterZonesProperty],

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/RequestUtils.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/RequestUtils.scala
@@ -30,7 +30,8 @@ object RequestUtils {
     validationFn: JsValue => JsResult[Response]
   ): R[Either[TravelTimeSdkError, Response]] = {
 
-    sttpRequest.backend
+    sttpRequest
+      .backend
       .send(sttpRequest.request)
       .map(_.body)
       .map(_.handleJsonResponse(validationFn))

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/RangeParams.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/requests/common/RangeParams.scala
@@ -3,6 +3,6 @@ package com.igeolise.traveltimesdk.dto.requests.common
 import scala.concurrent.duration.FiniteDuration
 
 object RangeParams {
-  case class FullRangeParams(enabled: Boolean, max_results: Int, width: FiniteDuration)
+  case class FullRangeParams(enabled: Boolean, maxResults: Int, width: FiniteDuration)
   case class RangeParams(enabled: Boolean, width: FiniteDuration)
 }

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterPostcodesResponse.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/dto/responses/timefilter/TimeFilterPostcodesResponse.scala
@@ -11,7 +11,7 @@ case class TimeFilterPostcodesResponse(results: Seq[SingleSearchResult], raw: Js
 object TimeFilterPostcodesResponse {
   case class SingleSearchResult(
     id: String,
-    postCodes: Seq[Postcode]
+    postcodes: Seq[Postcode]
   )
 
   case class Postcode(

--- a/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/CommonWrites.scala
+++ b/shared/src/main/scala/com/igeolise/traveltimesdk/json/writes/CommonWrites.scala
@@ -27,8 +27,7 @@ object CommonWrites {
   val finiteDurationToSecondsWrites: Writes[FiniteDuration] = Writes.IntWrites.contramap(_.toSeconds.toInt)
 
   implicit class formatDate(self: ZonedDateTime) {
-    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
-    def formatDate: String = self.format(dateFormatter)
+    def formatDate: String = self.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
   }
 
   def parameterlessTransportationJson(transportation: Transportation): JsObject =
@@ -115,7 +114,7 @@ object CommonWrites {
     (__ \ "id").write[String] and
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[CommonTransportation] and
-    (__ \ "arrival_time").write[String] and
+    (__ \ "arrival_time").write[ZonedDateTime] and
     (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "reachable_postcodes_threshold").write[Double] and
     (__ \ "properties").write[Seq[TimeFilterZonesProperty]] and
@@ -126,7 +125,7 @@ object CommonWrites {
     (__ \ "id").write[String] and
     (__ \ "coords").write[Coords] and
     (__ \ "transportation").write[CommonTransportation] and
-    (__ \ "departure_time").write[String] and
+    (__ \ "departure_time").write[ZonedDateTime] and
     (__ \ "travel_time").write[FiniteDuration](finiteDurationToSecondsWrites) and
     (__ \ "reachable_postcodes_threshold").write[Double] and
     (__ \ "properties").write[Seq[TimeFilterZonesProperty]] and

--- a/shared/src/test/resources/json/TimeFilter/request/timeFilterRequest-cycling-pt.json
+++ b/shared/src/test/resources/json/TimeFilter/request/timeFilterRequest-cycling-pt.json
@@ -37,7 +37,7 @@
         "boarding_time": 900
       },
       "travel_time": 1800,
-      "departure_time": "2019-07-08T08:00:00Z",
+      "departure_time": "2019-07-08T08:00:00+02:00",
       "range": {
         "enabled": true,
         "max_results": 3,
@@ -62,7 +62,7 @@
         "parking_time": 600,
         "boarding_time": 900
       },
-      "arrival_time": "2019-07-08T08:00:00Z",
+      "arrival_time": "2019-07-08T08:00:00+02:00",
       "travel_time": 1900,
       "properties": [
         "travel_time",

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/RoutesWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/RoutesWritesTest.scala
@@ -1,6 +1,6 @@
 package com.igeolise.traveltimesdk.writes
 
-import java.time.{ZoneId, ZonedDateTime}
+import java.time.ZonedDateTime
 
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.Coords
@@ -26,7 +26,7 @@ class RoutesWritesTest extends AnyFunSpec with Matchers {
       Location("Hyde Park", Coords(51.508824, -0.167093)),
       Location("ZSL London Zoo", Coords(51.536067, -0.153596))
     )
-    val time = ZonedDateTime.of(2018,10,2,8,0,0,0,ZoneId.systemDefault())
+    val time = ZonedDateTime.parse("2018-10-02T08:00:00+00:00")
 
     val routesDepartures = DepartureSearch(
       "departure search example",

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterWritesTest.scala
@@ -28,7 +28,7 @@ class TimeFilterWritesTest extends AnyFunSpec with Matchers {
       Location("ZSL London Zoo", Coords(51.536067, -0.153596))
     )
 
-    val time = ZonedDateTime.of(2018,9,27,8,0,0,0,ZoneId.systemDefault())
+    val time = ZonedDateTime.parse("2018-09-27T08:00:00Z")
 
     val timeFilterDepartures = DepartureSearch(
       "forward search example",
@@ -56,7 +56,7 @@ class TimeFilterWritesTest extends AnyFunSpec with Matchers {
     val timeFilterRequest = TimeFilterRequest(locations, Seq(timeFilterDepartures), Seq(timeFilterArrivals))
     val timeFilterJson = Json.toJson(timeFilterRequest)
 
-    timeFilterJson should equal (Json.parse(jsonResource))
+    timeFilterJson shouldBe Json.parse(jsonResource)
   }
 
   it("Make json request for time-filter request with cycling+public_transport transportation") {
@@ -66,7 +66,7 @@ class TimeFilterWritesTest extends AnyFunSpec with Matchers {
         Location("Science Museum", Coords(52.37421715421411, 4.912337064743042))
       )
 
-      val time = ZonedDateTime.of(2019,7,8,8,0,0,0,ZoneId.systemDefault())
+      val time = ZonedDateTime.parse("2019-07-08T08:00:00+02:00")
 
       val timeFilterDepartures = DepartureSearch(
         "forward search example",

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterZonesWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeFilterZonesWritesTest.scala
@@ -1,5 +1,7 @@
 package com.igeolise.traveltimesdk.writes
 
+import java.time.ZonedDateTime
+
 import com.igeolise.traveltimesdk.TestUtils
 import com.igeolise.traveltimesdk.dto.common.{Coords, ZoneSearches}
 import com.igeolise.traveltimesdk.dto.requests.common.CommonProperties.PropertyType.{Coverage, TravelTimeAll, TravelTimeReachable}
@@ -19,7 +21,7 @@ class TimeFilterZonesWritesTest extends AnyFunSpec with Matchers  {
     "public transport from Trafalgar Square",
     Coords(51.507609, -0.128315),
     Transportation.PublicTransport(PublicTransportationParams(None, None)),
-    "2018-10-01T08:00:00Z",
+    ZonedDateTime.parse("2018-10-01T08:00:00Z"),
     Duration(1800, SECONDS),
     0.1,
     Seq(
@@ -31,7 +33,7 @@ class TimeFilterZonesWritesTest extends AnyFunSpec with Matchers  {
     "public transport to Trafalgar Square",
     Coords(51.507609, -0.128315),
     Transportation.PublicTransport(PublicTransportationParams(None, None)),
-    "2018-10-01T08:00:00Z",
+    ZonedDateTime.parse("2018-10-01T08:00:00Z"),
     Duration(1800, SECONDS),
     0.1,
     Seq(

--- a/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeMapWritesTest.scala
+++ b/shared/src/test/scala/com/igeolise/traveltimesdk/writes/TimeMapWritesTest.scala
@@ -19,7 +19,7 @@ class TimeMapWritesTest extends AnyFunSpec with Matchers{
 
   it("departure_searches and arrival_searches json request") {
     val trans = PublicTransport(PublicTransportationParams(Some(Duration(1, MINUTES)), None))
-    val time = ZonedDateTime.of(2018,9,27,8,0,0,0,ZoneId.systemDefault())
+    val time = ZonedDateTime.parse("2018-09-27T08:00:00+00:00")
 
     val departure =
       TimeMapRequest.DepartureSearch(


### PR DESCRIPTION
* Fix: `ZonedDateTime` are being deserialized properly now using `DateTimeFormatter.ISO_OFFSET_DATE_TIME`
* Update: Tests updated to check proper timezone deserialization
* Update: `ZoneSearches` now contain `ZonedDateTime` for time instead of Strings
* Refactor: Typos in field names
* Bump: version